### PR TITLE
fix: propagate git auth values from secrets

### DIFF
--- a/pkg/runner/cypress.go
+++ b/pkg/runner/cypress.go
@@ -64,6 +64,13 @@ func (r *CypressRunner) Run(execution testkube.Execution) (result testkube.Execu
 		return result, err
 	}
 
+	if r.Params.GitUsername != "" && r.Params.GitToken != "" {
+		if execution.Content != nil && execution.Content.Repository != nil {
+			execution.Content.Repository.Username = r.Params.GitUsername
+			execution.Content.Repository.Token = r.Params.GitToken
+		}
+	}
+
 	path, err := r.Fetcher.Fetch(execution.Content)
 	if err != nil {
 		return result, err


### PR DESCRIPTION
## Pull request description 

Git auth fields are not propagated from secrets
Closes #983

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [ ] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Breaking changes

-

## Changes

-

## Fixes

- Pass git auth values to execution structure