### PR TITLE
fix: update example json to match the updated dashboard test structure

### DIFF
--- a/examples/test-git-dir.json
+++ b/examples/test-git-dir.json
@@ -8,8 +8,7 @@
 		"repository": {
 			"type": "git",
 			"uri": "https://github.com/kubeshop/testkube-dashboard.git",
-			"branch": "main",
-			"path": "test"
+			"branch": "main"
 		}
 	},
 	"startTime": "2021-11-04T12:14:57.118Z",


### PR DESCRIPTION
## Pull request description 

example/test-git-dir.json contains references to the Cypress tests in the testkube-dashboard repository. As these tests were recently refactored, the tests need to be updated as well

## Checklist (choose whats happened)

- [ ] breaking change! (describe)
- [x] tested locally
- [ ] tested on cluster
- [ ] added new dependencies
- [ ] updated the docs
- [ ] added a test

## Changes

- updated the example json to point to the root of the directory instead of the test folder
